### PR TITLE
Bump skein dependencies to allow run in arm64

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,6 +20,7 @@
     <grpc.version>1.16.0</grpc.version>
     <boringssl.version>2.0.17.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
+    <protobuf.version>3.0.0</protobuf.version>
     <hadoopVersion>2.7.2</hadoopVersion>
     <skein.version>UNKNOWN</skein.version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -44,7 +45,7 @@
             <activeByDefault>true</activeByDefault>
         </activation>
         <properties>
-            <archSuffix></archSuffix>
+            <archSuffix>${os.detected.classifier}</archSuffix>
         </properties>
     </profile>
 </profiles>
@@ -201,7 +202,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe${archSuffix}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe${archSuffix}</protocArtifact>
         </configuration>
         <executions>
           <execution>
@@ -211,7 +212,7 @@
             </goals>
             <configuration>
               <pluginId>lite</pluginId>
-              <pluginArtifact>com.google.protobuf:protoc-gen-javalite:3.0.0</pluginArtifact>
+              <pluginArtifact>com.google.protobuf:protoc-gen-javalite:${protobuf.version}</pluginArtifact>
             </configuration>
           </execution>
           <execution>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,32 @@
     <jetty.version>9.2.10.v20150310</jetty.version>
     <hadoopVersion>2.7.2</hadoopVersion>
     <skein.version>UNKNOWN</skein.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+
+  <profiles>
+    <profile>
+        <id>macos</id>
+        <activation>
+            <os>
+                <family>mac</family>
+            </os>
+        </activation>
+        <properties>
+            <archSuffix>:osx-x86_64</archSuffix>
+        </properties>
+    </profile>
+    <profile>
+        <id>default</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <properties>
+            <archSuffix></archSuffix>
+        </properties>
+    </profile>
+</profiles>
 
   <build>
     <resources>
@@ -176,7 +201,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe${archSuffix}</protocArtifact>
         </configuration>
         <executions>
           <execution>
@@ -196,7 +221,7 @@
             </goals>
             <configuration>
               <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe${archSuffix}</pluginArtifact>
               <pluginParameter>lite</pluginParameter>
             </configuration>
           </execution>
@@ -242,14 +267,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.1</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
           </compilerArgs>
           <!-- About source/target: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html -->
-          <source>7</source>
-          <target>7</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,11 +17,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.16.0</grpc.version>
+    <grpc.version>1.64.0</grpc.version>
     <boringssl.version>2.0.17.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
-    <protobuf.version>3.0.0</protobuf.version>
-    <hadoopVersion>2.7.2</hadoopVersion>
+    <protobuf.version>3.25.3</protobuf.version>
+    <hadoopVersion>3.3.5</hadoopVersion>
     <skein.version>UNKNOWN</skein.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -65,7 +65,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
 
@@ -200,7 +200,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe${archSuffix}</protocArtifact>
         </configuration>
@@ -212,7 +212,7 @@
             </goals>
             <configuration>
               <pluginId>lite</pluginId>
-              <pluginArtifact>com.google.protobuf:protoc-gen-javalite:${protobuf.version}</pluginArtifact>
+              <pluginArtifact>com.google.protobuf:protoc-java:${protobuf.version}</pluginArtifact>
             </configuration>
           </execution>
           <execution>
@@ -223,7 +223,6 @@
             <configuration>
               <pluginId>grpc-java</pluginId>
               <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe${archSuffix}</pluginArtifact>
-              <pluginParameter>lite</pluginParameter>
             </configuration>
           </execution>
         </executions>
@@ -340,7 +339,7 @@
 
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-protobuf-lite</artifactId>
+      <artifactId>grpc-protobuf</artifactId>
       <version>${grpc.version}</version>
     </dependency>
 
@@ -348,6 +347,13 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency> <!-- necessary for Java 9+ -->
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>annotations-api</artifactId>
+      <version>6.0.53</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
             <activeByDefault>true</activeByDefault>
         </activation>
         <properties>
-            <archSuffix>${os.detected.classifier}</archSuffix>
+            <archSuffix>:${os.detected.classifier}</archSuffix>
         </properties>
     </profile>
 </profiles>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.64.0</grpc.version>
-    <boringssl.version>2.0.17.Final</boringssl.version>
+    <boringssl.version>2.0.65.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <protobuf.version>3.25.3</protobuf.version>
     <hadoopVersion>3.3.5</hadoopVersion>
@@ -80,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -359,6 +359,12 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${boringssl.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-classes</artifactId>
       <version>${boringssl.version}</version>
     </dependency>
 

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -295,11 +295,12 @@ public class ApplicationMaster {
 
   private void startServer() throws IOException {
     // Setup and start the server
+    // Java 11 don't need to explicitly specify the SSL provider,
+    // as Java's built-in TLS implementation is used by default.
     SslContext sslContext = GrpcSslContexts
         .forServer(new File(".skein.crt"), new File(".skein.pem"))
         .trustManager(new File(".skein.crt"))
         .clientAuth(ClientAuth.REQUIRE)
-        .sslProvider(SslProvider.OPENSSL)
         .build();
 
     NioEventLoopGroup eg = new NioEventLoopGroup(NUM_EVENT_LOOP_GROUP_THREADS);

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -13,6 +13,7 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
@@ -313,6 +314,7 @@ public class ApplicationMaster {
     grpcServer = NettyServerBuilder.forPort(0)
         .sslContext(sslContext)
         .addService(new AppMasterImpl())
+        .channelType(NioServerSocketChannel.class)
         .workerEventLoopGroup(eg)
         .bossEventLoopGroup(eg)
         .executor(executor)

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -10,6 +10,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
@@ -125,7 +126,6 @@ public class Driver {
         .forServer(certBytes.newInput(), keyBytes.newInput())
         .trustManager(certBytes.newInput())
         .clientAuth(ClientAuth.REQUIRE)
-        .sslProvider(SslProvider.OPENSSL)
         .build();
 
     NioEventLoopGroup eg = new NioEventLoopGroup(NUM_EVENT_LOOP_GROUP_THREADS);
@@ -138,6 +138,7 @@ public class Driver {
     server = NettyServerBuilder.forAddress(new InetSocketAddress("127.0.0.1", 0))
         .sslContext(sslContext)
         .addService(new DriverImpl())
+        .channelType(NioServerSocketChannel.class)
         .workerEventLoopGroup(eg)
         .bossEventLoopGroup(eg)
         .executor(executor)

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -10,11 +10,10 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -443,7 +442,7 @@ public class Driver {
       appContext.setNodeLabelExpression(Strings.emptyToNull(spec.getNodeLabel()));
       appContext.setApplicationTags(spec.getTags());
       appContext.setLogAggregationContext(
-        LogAggregationContext.newInstance(
+          LogAggregationContext.newInstance(
             env.get("YARN_LOG_AGGREGATION_INCLUDE_PATTERN"),
             env.get("YARN_LOG_AGGREGATION_EXCLUDE_PATTERN")));
 

--- a/setup.py
+++ b/setup.py
@@ -166,10 +166,11 @@ is_build_step = bool({'build', 'install', 'develop',
                       'bdist_wheel'}.intersection(sys.argv))
 protos_built = bool(_compiled_protos()) and 'clean' not in sys.argv
 
-install_requires = ['grpcio>=1.11.0,!=1.45.0',
-                    'protobuf>=3.5.0',
+install_requires = ['protobuf>=3.5.0',
                     'pyyaml',
                     'cryptography']
+
+setup_requires = ['grpcio-tools!=1.45.0']
 
 # Due to quirks in setuptools/distutils dependency ordering, to get the java
 # and protobuf sources to build automatically in most cases, we need to check
@@ -214,5 +215,6 @@ setup(name='skein',
         skein=skein.cli:main
       ''',
       install_requires=install_requires,
+      setup_requires=setup_requires,
       python_requires=">=3.5",
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -171,8 +171,6 @@ install_requires = ['grpcio>=1.11.0,!=1.45.0',
                     'pyyaml',
                     'cryptography']
 
-setup_requires = ['grpcio-tools!=1.45.0']
-
 # Due to quirks in setuptools/distutils dependency ordering, to get the java
 # and protobuf sources to build automatically in most cases, we need to check
 # for them in multiple locations. This is unfortunate, but seems necessary.
@@ -216,6 +214,5 @@ setup(name='skein',
         skein=skein.cli:main
       ''',
       install_requires=install_requires,
-      setup_requires=setup_requires,
       python_requires=">=3.5",
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,8 @@ is_build_step = bool({'build', 'install', 'develop',
                       'bdist_wheel'}.intersection(sys.argv))
 protos_built = bool(_compiled_protos()) and 'clean' not in sys.argv
 
-install_requires = ['protobuf>=3.5.0',
+install_requires = ['grpcio>=1.11.0,!=1.45.0',
+                    'protobuf>=3.5.0',
                     'pyyaml',
                     'cryptography']
 


### PR DESCRIPTION
The new dependencies versions will allow build and run skein in arm64 architectures.

Tested with unit tests and manually.