### PR TITLE
Upgrade Grpcio and log skein start failure exception

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.66.0</grpc.version>
+    <grpc.version>1.69.1</grpc.version>
     <boringssl.version>2.0.65.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <protobuf.version>3.25.3</protobuf.version>

--- a/setup.py
+++ b/setup.py
@@ -166,12 +166,12 @@ is_build_step = bool({'build', 'install', 'develop',
                       'bdist_wheel'}.intersection(sys.argv))
 protos_built = bool(_compiled_protos()) and 'clean' not in sys.argv
 
-install_requires = ['grpcio==1.66.1',
+install_requires = ['grpcio==1.69.0',
                     'protobuf>=3.5.0',
                     'pyyaml',
                     'cryptography']
 
-setup_requires = ['grpcio-tools==1.66.1']
+setup_requires = ['grpcio-tools==1.69.0']
 
 # Due to quirks in setuptools/distutils dependency ordering, to get the java
 # and protobuf sources to build automatically in most cases, we need to check

--- a/skein/core.py
+++ b/skein/core.py
@@ -228,7 +228,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
         env['SKEIN_CALLBACK_PORT'] = str(callback_port)
 
         if log is None:
-            outfil = None
+            outfil = subprocess.PIPE
         elif log is False:
             outfil = subprocess.DEVNULL
         else:
@@ -254,7 +254,11 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                     port = struct.unpack("!i", msg)[0]
                     break
         else:
-            raise DriverError("Failed to start java process")
+            err = proc.stderr
+            if bool(log):
+                with open(log, 'r') as log_file:
+                    err = log_file.read()
+            raise DriverError(f"Failed to start java process. \nError: {err}")
 
     address = '127.0.0.1:%d' % port
 


### PR DESCRIPTION
Upgrade grpcio to v1.69 and log the skein start error in the error log.