### PR TITLE
Wait longer for callback, read full port number

### DIFF
--- a/skein/core.py
+++ b/skein/core.py
@@ -243,7 +243,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                                 start_new_session=True)
 
         while proc.poll() is None:
-            readable, _, _ = select.select([callback], [], [], 1)
+            readable, _, _ = select.select([callback], [], [], 60)
             if callback in readable:
                 connection = callback.accept()[0]
                 with closing(connection):
@@ -253,12 +253,12 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                         raise DriverError("Failed to read in client port")
                     port = struct.unpack("!i", msg)[0]
                     break
-        else:
-            err = proc.stderr
-            if bool(log):
-                with open(log, 'r') as log_file:
-                    err = log_file.read()
-            raise DriverError(f"Failed to start java process. \nError: {err}")
+            else:
+                err = proc.stderr
+                if bool(log):
+                    with open(log, 'r') as log_file:
+                        err = log_file.read()
+                raise DriverError(f"Failed to start java process. \nError: {err}")
 
     address = '127.0.0.1:%d' % port
 

--- a/skein/core.py
+++ b/skein/core.py
@@ -243,7 +243,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                                 start_new_session=True)
 
         while proc.poll() is None:
-            readable, _, _ = select.select([callback], [], [], 60)
+            readable, _, _ = select.select([callback], [], [], 10)
             if callback in readable:
                 connection = callback.accept()[0]
                 with closing(connection):

--- a/skein/core.py
+++ b/skein/core.py
@@ -248,7 +248,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                 connection = callback.accept()[0]
                 with closing(connection):
                     stream = connection.makefile(mode="rb")
-                    msg = stream.read(4)
+                    msg = stream.read(5)
                     if not msg:
                         raise DriverError("Failed to read in client port")
                     port = struct.unpack("!i", msg)[0]

--- a/skein/core.py
+++ b/skein/core.py
@@ -253,12 +253,12 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                         raise DriverError("Failed to read in client port")
                     port = struct.unpack("!i", msg)[0]
                     break
-            else:
-                err = proc.stderr
-                if bool(log):
-                    with open(log, 'r') as log_file:
-                        err = log_file.read()
-                raise DriverError(f"Failed to start java process. \nError: {err}")
+        else:
+            err = proc.stderr
+            if bool(log):
+                with open(log, 'r') as log_file:
+                    err = log_file.read()
+            raise DriverError(f"Failed to start java process. \nError: {err}")
 
     address = '127.0.0.1:%d' % port
 


### PR DESCRIPTION
This changes a couple things which seemed to be weird to me but I'm not actually sure if it will fix anything because I don't understand how this was even working at all in the first place.

First, I guess the way this worked before is `select.select()` had a 1s timeout so while the JVM driver is starting up the while loop would keep checking to see if the callback is ready. Maybe we can just have a longer timeout so there's less checking to see a `None` object returned all the time. (Seems weird to have a busy loop to wait on something to be ready when that something in itself is already blocking until ready but whatever.)

Second, more importantly, port numbers are up to 5 digits, before this is only reading the first 4 bytes for the port that the JVM driver is going to communicate on. I'm not sure how this ever worked in the first place but seems like it should be fixed?