### PR TITLE
Add pyproject.toml to fix build with newer pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "versioneer"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 import re
 import subprocess
 import sys
-import pkg_resources
 from distutils.command.build import build as _build
 from distutils.command.clean import clean as _clean
 from distutils.dir_util import remove_tree
@@ -48,8 +47,8 @@ class build_proto(Command):
             fil.write(''.join(new))
 
     def run(self):
-        from grpc_tools import protoc
-        include = pkg_resources.resource_filename('grpc_tools', '_proto')
+        import grpc_tools
+        include = os.path.join(os.path.dirname(grpc_tools.__file__), '_proto')
         for src in glob(os.path.join(JAVA_PROTO_DIR, "*.proto")):
             command = ['grpc_tools.protoc',
                        '--proto_path=%s' % JAVA_PROTO_DIR,
@@ -57,7 +56,7 @@ class build_proto(Command):
                        '--python_out=%s' % SKEIN_PROTO_DIR,
                        '--grpc_python_out=%s' % SKEIN_PROTO_DIR,
                        src]
-            if protoc.main(command) != 0:
+            if grpc_tools.protoc.main(command) != 0:
                 self.warn('Command: `%s` failed'.format(command))
                 sys.exit(1)
 


### PR DESCRIPTION
## Problem

Installing `skein` via pip fails with modern pip/setuptools due to build isolation:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

`setup.py` imports `pkg_resources` at module level, but modern pip does not include `setuptools` (which ships `pkg_resources`) in the isolated build environment unless explicitly declared via `pyproject.toml`. Additionally, `versioneer` is imported at module level in `setup.py` but was also not declared as a build requirement.

## Changes

- **Add `pyproject.toml`** declaring `setuptools`, `wheel`, and `versioneer` as build requirements so pip's isolated build environment has everything `setup.py` needs
- **Remove `import pkg_resources`** from `setup.py` and replace the one usage (`pkg_resources.resource_filename('grpc_tools', '_proto')`) with the equivalent `os.path.join(os.path.dirname(grpc_tools.__file__), '_proto')`

## Testing

Tested by running install