### PR TITLE
Fix grpc_tools.protoc submodule import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class build_proto(Command):
             fil.write(''.join(new))
 
     def run(self):
-        import grpc_tools
+        import grpc_tools.protoc
         include = os.path.join(os.path.dirname(grpc_tools.__file__), '_proto')
         for src in glob(os.path.join(JAVA_PROTO_DIR, "*.proto")):
             command = ['grpc_tools.protoc',


### PR DESCRIPTION
## Problem

After replacing `from grpc_tools import protoc` with `import grpc_tools` in #8, the Docker build fails with:

```
AttributeError: module 'grpc_tools' has no attribute 'protoc'
```

`import grpc_tools` does not automatically import submodules, so `grpc_tools.protoc` is not accessible as an attribute.

## Fix

Use `import grpc_tools.protoc` instead, which imports the submodule and makes it accessible as `grpc_tools.protoc`, while still allowing `grpc_tools.__file__` to resolve the `_proto` include path.